### PR TITLE
Automatically add URL pair to database with a new issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Add Short URL
+
+on: 
+  issue_comment:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+      
+    - name: Create local changes
+      run: python add_url.py
+
+    - name: Commit files
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "Add short URL" -a
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/add_url.py
+++ b/add_url.py
@@ -1,0 +1,18 @@
+import os
+from github import Github
+
+github = Github(os.environ["GITHUB_TOKEN"])
+repo = github.get_repo(os.environ["GITHUB_REPOSITORY"])
+open_issues = repo.get_issues(state="open")
+
+for issue in open_issues:
+	if issue.title == "Add URL":
+		if issue.user.login == "paramt":
+			issue.body = "test --> https://www.param.me/test"
+			with open("redirects.csv", "a") as csv:
+				line = issue.body.replace(" --> ", ",")
+				csv.write(line)
+				csv.write("\n")
+
+			issue.create_comment("The redirect has been added! Please allow up to 5 minutes for the changes to take place.")
+			issue.edit(state="closed")


### PR DESCRIPTION
[WIP - closes #1]

### Progress
- [x] Create workflow
- [x] Create a script that adds the short URL to `redirects.csv`

### References
- [GitHub API for issues](https://developer.github.com/v3/issues/)
- [Authenticating with the GITHUB_TOKEN](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token)
- [Example of pushing changes using GitHub Actions](https://github.com/Seniru/LineGraph-TFM/blob/master/.github/workflows/build.yml)
- [GitHub Action that commits to GitHub](https://garethr.dev/2019/09/github-actions-that-commit-to-github/)